### PR TITLE
terraform gitlab

### DIFF
--- a/provisioning/terragrunt/bootstrap/module/main.tf
+++ b/provisioning/terragrunt/bootstrap/module/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  backend "consul" {}
+  backend "http" {}
 }
 
 locals {

--- a/provisioning/terragrunt/hosts/module/main.tf
+++ b/provisioning/terragrunt/hosts/module/main.tf
@@ -1,3 +1,3 @@
 terraform {
-  backend "consul" {}
+  backend "http" {}
 }

--- a/provisioning/terragrunt/terragrunt.hcl
+++ b/provisioning/terragrunt/terragrunt.hcl
@@ -1,10 +1,13 @@
 remote_state {
-  backend = "consul" 
+  backend = "http"
   config = {
-    address = "consul.castle.local:8501"
-    scheme  = "https"
-    path    = "${get_env("OS_USER_DOMAIN_NAME","aecid")}/projects/${get_env("OS_PROJECT_NAME","aecid-testbed")}/environment/${path_relative_to_include()}/terraform.tfstate"
-    lock = true
-    access_token = "${get_env("CONSUL_HTTP_TOKEN")}"
+    address        = "https://git-service.ait.ac.at/api/v4/projects/2197/terraform/state/${get_env("OS_PROJECT_NAME")}_${get_env("OS_USER_DOMAIN_NAME")}_${path_relative_to_include()}_${basename(get_repo_root())}"
+    lock_address   = "https://git-service.ait.ac.at/api/v4/projects/2197/terraform/state/${get_env("OS_PROJECT_NAME")}_${get_env("OS_USER_DOMAIN_NAME")}_${path_relative_to_include()}_${basename(get_repo_root())}/lock"
+    unlock_address = "https://git-service.ait.ac.at/api/v4/projects/2197/terraform/state/${get_env("OS_PROJECT_NAME")}_${get_env("OS_USER_DOMAIN_NAME")}_${path_relative_to_include()}_${basename(get_repo_root())}/lock"
+    username       = "${get_env("GITLAB_USERNAME")}"
+    password       = "${get_env("CR_GITLAB_ACCESS_TOKEN")}"
+    lock_method    = "POST"
+    unlock_method  = "DELETE"
+    retry_wait_min = "5"
   }
 }


### PR DESCRIPTION
obsoletes CONSUL_HTTP_TOKEN.
Requires GITLAB_USERNAME & CR_GITLAB_ACCESS_TOKEN to be set.

See https://git-service.ait.ac.at/sct-cyberrange/packages/terraform-state for details